### PR TITLE
Set hosts_interface to internal_interface by default

### DIFF
--- a/all/099-interfaces.yml
+++ b/all/099-interfaces.yml
@@ -31,7 +31,6 @@ tunnel_address_family: "{{ network_address_family }}"
 # NOTE: default interfaces as used in OSISM playbooks + roles
 
 console_interface: "{{ internal_interface|default(eth0) }}"
-management_interface: "{{ internal_interface|default(eth0) }}"
-
-# NOTE: default interfaces as used in k3s-ansible
+hosts_interface: "{{ internal_interface|default(eth0) }}"
 k3s_interface: "{{ internal_interface|default(eth0) }}"
+management_interface: "{{ internal_interface|default(eth0) }}"


### PR DESCRIPTION
This can simplify the osism.commons.hosts template.

Signed-off-by: Christian Berendt <berendt@osism.tech>