### PR TITLE
Add lsscsi + nvme-cli to required_packages_default

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -66,6 +66,8 @@ required_packages_default:
   - tmux
   - tree
   - whois
+  - nvme-cli
+  - lsscsi
 
 ##########################
 # network


### PR DESCRIPTION
Add nvme-cli and lsscsi as mentioned in https://github.com/osism/issues/issues/634

Signed-off-by: Paul-Philipp Kuschy <kuschy@osism.tech>