### PR TITLE
Add enable_ironic_dnsmasq parameter

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -90,4 +90,5 @@ ceilometer_central_enable_healthchecks: "no"
 gnocchi_statsd_enable_healthchecks: "no"
 
 # required to be backward compatible
+enable_ironic_dnsmasq: "no"
 enable_skydive: "no"


### PR DESCRIPTION
Required to be backward compatible.