### PR TITLE
Add rabbitmq_datadir_volume

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -81,6 +81,11 @@ fluentd_enable_watch_timer: "true"
 glance_enable_rolling_upgrade: "yes"
 
 ##########################################################
+# Custom features
+
+rabbitmq_datadir_volume: "rabbitmq"
+
+##########################################################
 # Bugfixes
 
 # NOTE: https://github.com/osism/issues/issues/231


### PR DESCRIPTION
Required for our custom rabbitmq datadir volume.