### PR TITLE
kolla: add missing ironic interface parameters

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -250,6 +250,7 @@ bifrost_network_interface: "{{ network_interface }}"
 dns_interface: "{{ network_interface }}"
 dpdk_tunnel_interface: "{{ neutron_external_interface }}"
 ironic_http_interface: "{{ api_interface }}"
+ironic_tftp_interface: "{{ api_interface }}"
 
 # Configure the address family (AF) per network.
 # Valid options are [ ipv4, ipv6 ]
@@ -265,12 +266,14 @@ bifrost_network_address_family: "{{ network_address_family }}"
 dns_address_family: "{{ network_address_family }}"
 dpdk_tunnel_address_family: "{{ network_address_family }}"
 ironic_http_address_family: "{{ api_address_family }}"
+ironic_tftp_address_family: "{{ api_address_family  }}"
 
 migration_interface_address: "{{ 'migration' | kolla_address }}"
 tunnel_interface_address: "{{ 'tunnel' | kolla_address }}"
 octavia_network_interface_address: "{{ 'octavia_network' | kolla_address }}"
 dpdk_tunnel_interface_address: "{{ 'dpdk_tunnel' | kolla_address }}"
 ironic_http_interface_address: "{{ 'ironic_http' | kolla_address }}"
+ironic_tftp_interface_address: "{{ 'ironic_tftp' | kolla_address }}"
 
 # Valid options are [ openvswitch, ovn, linuxbridge, vmware_nsxv, vmware_nsxv3, vmware_nsxp, vmware_dvs ]
 # Do note linuxbridge is *EXPERIMENTAL* in Neutron since Zed and it requires extra tweaks to config to be usable.


### PR DESCRIPTION
Have been introduced through a backport on kolla-ansibl@stable/2023.1 and are therefore not yet there.