### PR TITLE
Add skyline_internal_fqdn & skyline_external_fqdn

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -630,6 +630,8 @@ senlin_api_port: "8778"
 senlin_api_listen_port: "{{ senlin_api_port }}"
 senlin_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else senlin_api_port }}"
 
+skyline_internal_fqdn: "{{ kolla_internal_fqdn }}"
+skyline_external_fqdn: "{{ kolla_external_fqdn }}"
 skyline_apiserver_internal_fqdn: "{{ kolla_internal_fqdn }}"
 skyline_apiserver_external_fqdn: "{{ kolla_external_fqdn }}"
 skyline_console_internal_fqdn: "{{ kolla_internal_fqdn }}"


### PR DESCRIPTION
Required by OpenStack Zed & OpenStack 2023.1.