### PR TITLE
Remove some packages by default

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -162,6 +162,12 @@ proxy_proxies: {}
 ##########################
 # cleanup
 
+cleanup_packages_default:
+  - lxc
+  - lxd-agent-loader
+  - pastebinit
+  - telnet
+
 cleanup_services_default:
   - ModemManager.service
 


### PR DESCRIPTION
Those packages are installed by default when working the the Ubuntu ISO installer and should be removed by default.