### PR TITLE
k3s: add cilium_bgp parameter

### DIFF
--- a/all/099-k3s.yml
+++ b/all/099-k3s.yml
@@ -7,6 +7,9 @@ kube_vip_tag_version: "v0.6.4"
 metal_lb_controller_tag_version: "v0.13.12"
 metal_lb_speaker_tag_version: "v0.13.12"
 
+# features
+cilium_bgp: false
+
 # apiserver_endpoint is virtual ip-address which will be configured on each master
 # This default refers to the OSISM testbed and must always be adjusted when using K3s.
 apiserver_endpoint: "192.168.16.8"


### PR DESCRIPTION
This has to be set now by default (it's the default in k3s-ansible also, the cilium_bgp parameter has to be part of the group_vars).