### PR TITLE
Use default repositories from osism.commons.repository

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -91,19 +91,6 @@ rsyslog_fluentd_host: "{{ internal_address }}"
 ##########################
 # repository
 
-repository_keys: []
-repository_key_ids: {}
-
-repositories:
-  - name: "{{ ansible_distribution_release }}"
-    repository: "deb [arch=amd64] http://de.archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }} main restricted universe multiverse"
-  - name: "{{ ansible_distribution_release }}-backports"
-    repository: "deb [arch=amd64] http://de.archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }}-backports main restricted universe multiverse"
-  - name: "{{ ansible_distribution_release }}-security"
-    repository: "deb [arch=amd64] http://de.archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }}-security main restricted universe multiverse"
-  - name: "{{ ansible_distribution_release }}-updates"
-    repository: "deb [arch=amd64] http://de.archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }}-updates main restricted universe multiverse"
-
 docker_configure_repository: true
 falco_configure_repository: true
 lynis_configure_repository: true


### PR DESCRIPTION
This is necessary so that multiple different distributions are supported by default without further customisation.

The default in osism.commons.repository for Ubuntu corresponds exactly to these entries that will be removed. The default behaviour does not change when deployed on Ubuntu.