### PR TITLE
Use default packages from osism.commons.packages

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -33,43 +33,6 @@ grub_hidden_timeout: false
 timezone_name: UTC
 
 ##########################
-# packages
-
-required_packages_default:
-  - command-not-found
-  - curl
-  - debconf
-  - debsums
-  - dmidecode
-  - ethtool
-  - ethtool
-  - htop
-  - iftop
-  - iotop
-  - iperf
-  - jq
-  - ltrace
-  - mosh
-  - mtr
-  - multitail
-  - ncdu
-  - netcat
-  - pciutils
-  - pstack
-  - pv
-  - python-is-python3
-  - rsyslog
-  - selinux-utils
-  - socat
-  - ssh
-  - sysstat
-  - tmux
-  - tree
-  - whois
-  - nvme-cli
-  - lsscsi
-
-##########################
 # network
 
 network_allow_service_restart: false


### PR DESCRIPTION
This is necessary so that multiple different distributions are supported by default without further customisation.

The new default in osism.commons.packages for Ubuntu corresponds exactly to these entries that will be removed. The default behaviour does not change when deployed on Ubuntu.

Related to osism/ansible-collection-commons#628