### PR TITLE
Use default cleanups from osism.commons.cleanup

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -110,18 +110,6 @@ security_sshd_allowed_macs: hmac-sha2-256,hmac-sha2-512,hmac-sha1
 proxy_proxies: {}
 
 ##########################
-# cleanup
-
-cleanup_packages_default:
-  - lxc
-  - lxd-agent-loader
-  - pastebinit
-  - telnet
-
-cleanup_services_default:
-  - ModemManager.service
-
-##########################
 # services
 
 enable_auditd: false


### PR DESCRIPTION
This is necessary so that multiple different distributions are supported by default without further customisation.

The new defaults in osism.commons.cleanup for Ubuntu corresponds exactly to these entries that will be removed. The default behaviour does not change when deployed on Ubuntu.

Related to osism/ansible-collection-commons#633