### PR TITLE
Add k3s monitoring defaults

### DIFF
--- a/all/099-k3s.yml
+++ b/all/099-k3s.yml
@@ -33,6 +33,7 @@ k3s_master_taint: "{{ true if groups['k3s_node'] | default([]) | length >= 1 els
 
 # monitoring
 k3s_monitoring: true
+k3s_monitoring_bind_address: "0.0.0.0"
 k3s_monitoring_scheduler_port: "10259"
 k3s_monitoring_controller_manage_port: "10257"
 
@@ -44,11 +45,11 @@ extra_args: >-
 # monitoring arguments instruct k3s servers to expose control plane metrics:
 monitoring_args: >-
   --etcd-expose-metrics
-  --kube-proxy-arg "metrics-bind-address=0.0.0.0"
-  --kube-scheduler-arg "bind-address=0.0.0.0"
+  --kube-proxy-arg "metrics-bind-address={{ k3s_monitoring_bind_address }}"
+  --kube-scheduler-arg "bind-address={{ k3s_monitoring_bind_address }}"
   --kube-scheduler-arg "secure-port={{ k3s_monitoring_scheduler_port }}"
   --kube-scheduler-arg "authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics"
-  --kube-controller-manager-arg "bind-address=0.0.0.0"
+  --kube-controller-manager-arg "bind-address={{ k3s_monitoring_bind_address }}"
   --kube-controller-manager-arg "secure-port={{ k3s_monitoring_controller_manage_port }}"
   --kube-controller-manager-arg "authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics"
 

--- a/all/099-k3s.yml
+++ b/all/099-k3s.yml
@@ -31,14 +31,31 @@ k3s_node_ip: '{{ ansible_facts[k3s_interface]["ipv4"]["address"] }}'
 # Disable the taint manually by setting: k3s_master_taint = false
 k3s_master_taint: "{{ true if groups['k3s_node'] | default([]) | length >= 1 else false }}"
 
+# monitoring
+k3s_monitoring: true
+k3s_monitoring_scheduler_port: "10259"
+k3s_monitoring_controller_manage_port: "10257"
+
 # these arguments are recommended for servers as well as agents:
 extra_args: >-
   --flannel-iface={{ k3s_interface }}
   --node-ip={{ k3s_node_ip }}
 
+# monitoring arguments instruct k3s servers to expose control plane metrics:
+monitoring_args: >-
+  --etcd-expose-metrics
+  --kube-proxy-arg "metrics-bind-address=0.0.0.0"
+  --kube-scheduler-arg "bind-address=0.0.0.0"
+  --kube-scheduler-arg "secure-port={{ k3s_monitoring_scheduler_port }}"
+  --kube-scheduler-arg "authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics"
+  --kube-controller-manager-arg "bind-address=0.0.0.0"
+  --kube-controller-manager-arg "secure-port={{ k3s_monitoring_controller_manage_port }}"
+  --kube-controller-manager-arg "authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics"
+
 # change these to your liking, the only required are: --disable servicelb, --tls-san {{ apiserver_endpoint }}
 extra_server_args: >-
   {{ extra_args }}
+  {{ monitoring_args if k3s_monitoring else '' }}
   {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_master_taint else '' }}
   --tls-san {{ apiserver_endpoint }}
   --disable servicelb


### PR DESCRIPTION
This PR adds the k3s monitoring arguments to the k3s servers. 
The k3s configuration has been tested with testbed deployment. In addition, this configuration is already a part SCS observability quickstart guide for k3s monitoring https://github.com/SovereignCloudStack/k8s-observability/pull/49

Open question:
- Should be `k3s_monitoring: true` default?

Related to: https://github.com/SovereignCloudStack/issues/issues/576