### PR TITLE
Set ceph dashboard standby behaviour

### DIFF
--- a/all/099-ceph.yml
+++ b/all/099-ceph.yml
@@ -259,3 +259,9 @@ ceph_origin: dummy
 ceph_repository: dummy
 journal_size: 5120
 radosgw_frontend_type: beast
+
+##########################
+# dashboard
+
+ceph_dashboard_standby_behaviour: error
+ceph_dashboard_standby_error_status_code: 404


### PR DESCRIPTION
Set ceph dashboard standby to error with status 404

Part of https://github.com/osism/issues/issues/1013