### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/bobact-a9dd7a0c8c21bdb8.yaml
+++ b/releasenotes/notes/bobact-a9dd7a0c8c21bdb8.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Sync `all/001-kolla-defaults.yml` with defaults of `stable/2023.2`.

--- a/releasenotes/notes/kolla-enable_octavia_jobboard-18de19c6a285fe7e.yaml
+++ b/releasenotes/notes/kolla-enable_octavia_jobboard-18de19c6a285fe7e.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Add `enable_octavia_jobboard` parameter.

--- a/releasenotes/notes/kolla-om_enable_rabbitmq_quorum_queues-4403028bb97d8c18.yaml
+++ b/releasenotes/notes/kolla-om_enable_rabbitmq_quorum_queues-4403028bb97d8c18.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Add new `om_enable_rabbitmq_quorum_queues` kolla default parameter.

--- a/releasenotes/notes/new-default-for-hosts-type-70057feded5fbb27.yaml
+++ b/releasenotes/notes/new-default-for-hosts-type-70057feded5fbb27.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    The default value for `hosts_type` is now `template`.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.