### PR TITLE
kolla: fix node_custom_config

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -26,7 +26,7 @@ kolla_base_distro: ubuntu
 kolla_install_type: source
 
 config_strategy: COPY_ALWAYS
-node_custom_config: "{{ configuration_directory }}/environments/kolla/files/overlays"
+node_custom_config: "{{ node_config }}/files/overlays"
 
 docker_namespace: osism
 docker_registry_kolla: quay.io


### PR DESCRIPTION
node_config is set to the correct environment by the run.sh script in the kolla-ansible container. This is important when working with sub-environments. Therefore node_custom_config must access node_config as otherwise the correct sub environment is not used.