### PR TITLE
Delete the osism user by default

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -77,6 +77,12 @@ chrony_allowed_subnets:
   - 127.0.0.1/32
 
 ##########################
+# user
+
+user_delete:
+  - osism
+
+##########################
 # operator
 
 deploy_user: ubuntu


### PR DESCRIPTION
The osism user is used on osism/node-image. It shoue be removed after the initial bootstrap. So that you don't have to do this manually, it will be removed by default from now on.