### PR TITLE
Re-add the kube_vip_tag_version parameter

### DIFF
--- a/all/099-k3s.yml
+++ b/all/099-k3s.yml
@@ -4,6 +4,7 @@ group_name_master: k3s_master
 # versions
 k3s_version: v1.29.2+k3s1
 cilium_tag: "v1.15.2"
+kube_vip_tag_version: "v0.7.2"
 
 # apiserver_endpoint is virtual ip-address which will be configured on each master
 apiserver_endpoint: "192.168.16.8"


### PR DESCRIPTION
The "Copy vip manifest to first master" task is always executed and requires the kube_vip_tag_version parameter.

Related to 40e79118629bf2775a45bb9767afa74ed9fddc00