### PR TITLE
Enable cilium hubble by default

### DIFF
--- a/all/099-k3s.yml
+++ b/all/099-k3s.yml
@@ -30,7 +30,7 @@ k3s_monitoring_controller_manage_port: "10257"
 
 # cilium
 cilium_mode: "native"
-cilium_hubble: false
+cilium_hubble: true
 cilium_bgp: false
 
 cilium_bgp_my_asn: "64513"


### PR DESCRIPTION
This is only used if Cilium is also used.

Revert 18e107a191bd8e3b98519a0b201a15a2b2d59426