### PR TITLE
Add nexus_bind_host parameter

### DIFF
--- a/all/099-infrastructure.yml
+++ b/all/099-infrastructure.yml
@@ -51,6 +51,7 @@ virtualbmc_host: "{{ hostvars[inventory_hostname]['ansible_' + management_interf
 # nexus
 
 nexus_host: "{{ hostvars[inventory_hostname]['ansible_' + management_interface]['ipv4']['address'] }}"
+nexus_bind_host: "{{ hostvars[inventory_hostname]['ansible_' + management_interface]['ipv4']['address'] }}"
 
 ##########################
 # boundary


### PR DESCRIPTION
Do not bind Nexus proxy ports by default on 0.0.0.0.