### PR TITLE
ceph: always use docker as container binary

### DIFF
--- a/all/099-ceph.yml
+++ b/all/099-ceph.yml
@@ -15,6 +15,8 @@ ceph_uid: 64045
 bootstrap_dirs_owner: "64045"
 bootstrap_dirs_group: "64045"
 
+container_binary: docker
+
 ##########################
 # osd
 


### PR DESCRIPTION
We do not support podman at the moment. Always use docker as container binary and do not auto detect if podman is usable.