### PR TITLE
Revert "ceph: always use docker as container binary (#218)"

### DIFF
--- a/all/099-ceph.yml
+++ b/all/099-ceph.yml
@@ -15,8 +15,6 @@ ceph_uid: 64045
 bootstrap_dirs_owner: "64045"
 bootstrap_dirs_group: "64045"
 
-container_binary: docker
-
 ##########################
 # osd
 


### PR DESCRIPTION
This reverts commit 63bf278b1aa0fb5af9eade2c94f071d3c8100059.

We add a patch to osism/container-image-ceph-ansible to modify container_binary.yml. There are a lot of "tasks_from: container_binary.yml" in ceph-ansible.