### PR TITLE
Make quorum queues the default

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -268,9 +268,10 @@ om_enable_rabbitmq_tls: "{{ rabbitmq_enable_tls | bool }}"
 # CA certificate bundle in containers using oslo.messaging with RabbitMQ TLS.
 om_rabbitmq_cacert: "{{ rabbitmq_cacert }}"
 
+# When quorum queues are enabled by om_enable_rabbitmq_quorum_queues,
+# om_enable_rabbitmq_high_availability needs to be disabled
 om_enable_rabbitmq_high_availability: false
-# Only enable quorum queues if you disable om_enable_rabbitmq_high_availability
-om_enable_rabbitmq_quorum_queues: false
+om_enable_rabbitmq_quorum_queues: true
 
 ####################
 # Networking options


### PR DESCRIPTION
I think it's time to activate the quorum queues. 
I also think 
- it would be good to point out to the OSISM users in the release letter that this is now the default.
- it would be very useful if we could migrate the existing queues without API downtime using a migration routine.
(something like: create a temporary queue, switch Exchange to it, delete the old queue after it has emptied, create a new queue, switch Exchange to the new queue)