### PR TITLE
k3s: update versions

### DIFF
--- a/all/099-k3s.yml
+++ b/all/099-k3s.yml
@@ -2,9 +2,9 @@
 group_name_master: k3s_master
 
 # versions
-cilium_tag: "v1.16.1"
-k3s_version: v1.30.4+k3s1
-kube_vip_tag_version: "v0.8.2"
+cilium_tag: "v1.16.4"
+k3s_version: v1.30.6+k3s1
+kube_vip_tag_version: "v0.8.7"
 metal_lb_controller_tag_version: "v0.14.8"
 metal_lb_speaker_tag_version: "v0.14.8"
 


### PR DESCRIPTION
* cilium_tag: v1.16.4
* k3s_version: v1.30.6+k3s1
* kube_vip_tag_version: v0.8.7