### PR TITLE
Disable ironic_prometheus_exporter (#2557)

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -60,6 +60,7 @@ horizon_backend_database: "yes"
 
 # ironic
 ironic_agent_files_directory: /share/ironic
+enable_ironic_prometheus_exporter: false
 
 # keystone
 keystone_token_provider: "fernet"


### PR DESCRIPTION
The ironic_prometheus_exporter is broken right now and cannot be scraped. The error is in the ironic-conductor ([1]) while fetching the metrics.

[1]
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager [-] An unknown error occurred while attempting to collect sensor data from within the conductor. Error: Metrics action is not supported. You may need to adjust the [metrics] section in ironic.conf.: ironic_lib.exception.MetricsNotSupported: Metrics action is not supported. You may need to adjust the [metrics] section in iro nic.conf.
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager Traceback (most recent call last):
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager   File "/var/lib/kolla/venv/lib/python3.10/site-packages/ironic/conductor/manager.py", line 2681, in _sensors_conductor
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager     sensors_data = METRICS.get_metrics_data()
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager   File "/var/lib/kolla/venv/lib/python3.10/site-packages/ironic_lib/metrics.py", line 295, in get_metrics_data
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager     raise exception.MetricsNotSupported()
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager ironic_lib.exception.MetricsNotSupported: Metrics action is not supported. You may need to adjust the [metrics] section in ironic.conf.
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager
2024-12-07 10:18:45.319 7 DEBUG futurist.periodics [-] Submitting periodic callback 'ironic.conductor.manager.ConductorManager._send_sensor_data' _process_scheduled /var/lib/kolla/venv/lib/python3.10/site-packages/futurist/periodics.py:638
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager [-] An unknown error occurred while attempting to collect sensor data from within the conductor. Error: Metrics action is not supported. You may need to adjust the [metrics] section in ironic.conf.: ironic_lib.exception.MetricsNotSupported: Metrics action is not supported. You may need to adjust the [metrics] section in iro
nic.conf.
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager Traceback (most recent call last):
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager   File "/var/lib/kolla/venv/lib/python3.10/site-packages/ironic/conductor/manager.py", line 2681, in _sensors_conductor
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager     sensors_data = METRICS.get_metrics_data()
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager   File "/var/lib/kolla/venv/lib/python3.10/site-packages/ironic_lib/metrics.py", line 295, in get_metrics_data
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager     raise exception.MetricsNotSupported()
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager ironic_lib.exception.MetricsNotSupported: Metrics action is not supported. You may need to adjust the [metrics] section in ironic.conf.
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager