### PR TITLE
k3s: do not manage cilium CLI with k3s-ansible

### DIFF
--- a/all/099-k3s.yml
+++ b/all/099-k3s.yml
@@ -30,6 +30,7 @@ k3s_monitoring_controller_manage_port: "10257"
 
 # cilium
 cilium_mode: "native"
+cilium_cli: false
 cilium_hubble: false
 cilium_hubble_ui_lb: true
 cilium_bgp: true


### PR DESCRIPTION
The cilium CLI is pre-installed in osism/osism-kubernetes container image.