### PR TITLE
Update network interface from eth0 to loopback0

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -293,7 +293,7 @@ om_enable_rabbitmq_stream_fanout: "{{ om_enable_rabbitmq_quorum_queues | bool an
 ####################
 # Networking options
 ####################
-network_interface: "eth0"
+network_interface: "loopback0"
 neutron_external_interface: "eth1"
 kolla_external_vip_interface: "{{ network_interface }}"
 api_interface: "{{ network_interface }}"

--- a/all/099-interfaces.yml
+++ b/all/099-interfaces.yml
@@ -1,7 +1,7 @@
 ---
 # default interfaces as defined in kolla-ansible
 
-network_interface: "eth0"
+network_interface: "loopback0"
 
 api_interface: "{{ network_interface }}"
 bifrost_network_interface: "{{ network_interface }}"
@@ -30,13 +30,13 @@ tunnel_address_family: "{{ network_address_family }}"
 
 # default interfaces as used in OSISM playbooks + roles
 
-console_interface: "{{ internal_interface|default(eth0) }}"
-hosts_interface: "{{ internal_interface|default(eth0) }}"
-management_interface: "{{ internal_interface|default(eth0) }}"
+console_interface: "{{ internal_interface|default(loopback0) }}"
+hosts_interface: "{{ internal_interface|default(loopback0) }}"
+management_interface: "{{ internal_interface|default(loopback0) }}"
 
 # default interfaces as defined in k3s-ansible
 
-k3s_interface: "{{ internal_interface|default(eth0) }}"
+k3s_interface: "{{ internal_interface|default(loopback0) }}"
 cilium_iface: "{{ k3s_interface }}"
 kube_vip_iface: "{{ k3s_interface }}"
 


### PR DESCRIPTION
Changes default network interface configuration across kolla defaults and interface definitions to use loopback0 instead of eth0.