### PR TITLE
kolla: enable valkey

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -10,6 +10,7 @@ enable_central_logging: "yes"
 enable_prometheus: "yes"
 enable_redis: "yes"
 enable_grafana: "yes"
+enable_valkey: "yes"
 
 # openstack
 


### PR DESCRIPTION
Enable Valkey in the kolla defaults by adding `enable_valkey: "yes"` to `099-kolla.yml`.