### PR TITLE
Remove orphaned kolla service config

### DIFF
--- a/all/002-images-kolla.yml
+++ b/all/002-images-kolla.yml
@@ -146,19 +146,6 @@ masakari_monitors_image: "{{ docker_image_url }}masakari-monitors"
 masakari_monitors_tag: "{{ masakari_tag }}"
 
 ##############################
-# role: senlin
-
-senlin_tag: "{{ kolla_senlin_version|default(kolla_image_version) }}"
-senlin_conductor_image: "{{ docker_image_url }}senlin-conductor"
-senlin_conductor_tag: "{{ senlin_tag }}"
-senlin_engine_image: "{{ docker_image_url }}senlin-engine"
-senlin_engine_tag: "{{ senlin_tag }}"
-senlin_health_manager_image: "{{ docker_image_url }}senlin-health-manager"
-senlin_health_manager_tag: "{{ senlin_tag }}"
-senlin_api_image: "{{ docker_image_url }}senlin-api"
-senlin_api_tag: "{{ senlin_tag }}"
-
-##############################
 # role: keystone
 
 keystone_tag: "{{ kolla_keystone_version|default(kolla_image_version) }}"

--- a/all/002-images-kolla.yml
+++ b/all/002-images-kolla.yml
@@ -26,15 +26,6 @@ heat_engine_image: "{{ docker_image_url }}heat-engine"
 heat_engine_tag: "{{ heat_tag }}"
 
 ##############################
-# role: murano
-
-murano_tag: "{{ kolla_murano_version|default(kolla_image_version) }}"
-murano_api_image: "{{ docker_image_url }}murano-api"
-murano_api_tag: "{{ murano_tag }}"
-murano_engine_image: "{{ docker_image_url }}murano-engine"
-murano_engine_tag: "{{ murano_tag }}"
-
-##############################
 # role: manila
 
 manila_tag: "{{ kolla_manila_version|default(kolla_image_version) }}"
@@ -155,19 +146,6 @@ masakari_monitors_image: "{{ docker_image_url }}masakari-monitors"
 masakari_monitors_tag: "{{ masakari_tag }}"
 
 ##############################
-# role: solum
-
-solum_tag: "{{ kolla_solum_version|default(kolla_image_version) }}"
-solum_worker_image: "{{ docker_image_url }}solum-worker"
-solum_worker_tag: "{{ solum_tag }}"
-solum_deployer_image: "{{ docker_image_url }}solum-deployer"
-solum_deployer_tag: "{{ solum_tag }}"
-solum_conductor_image: "{{ docker_image_url }}solum-conductor"
-solum_conductor_tag: "{{ solum_tag }}"
-solum_api_image: "{{ docker_image_url }}solum-api"
-solum_api_tag: "{{ solum_tag }}"
-
-##############################
 # role: senlin
 
 senlin_tag: "{{ kolla_senlin_version|default(kolla_image_version) }}"
@@ -192,21 +170,6 @@ keystone_ssh_image: "{{ docker_image_url }}keystone-ssh"
 keystone_ssh_tag: "{{ keystone_tag }}"
 keystone_httpd_image: "{{ docker_image_url }}httpd"
 keystone_httpd_tag: "{{ keystone_tag }}"
-
-##############################
-# role: vitrage
-
-vitrage_tag: "{{ kolla_vitrage_version|default(kolla_image_version) }}"
-vitrage_graph_image: "{{ docker_image_url }}vitrage-graph"
-vitrage_graph_tag: "{{ vitrage_tag }}"
-vitrage_api_image: "{{ docker_image_url }}vitrage-api"
-vitrage_api_tag: "{{ vitrage_tag }}"
-vitrage_notifier_image: "{{ docker_image_url }}vitrage-notifier"
-vitrage_notifier_tag: "{{ vitrage_tag }}"
-vitrage_ml_image: "{{ docker_image_url }}vitrage-ml"
-vitrage_ml_tag: "{{ vitrage_tag }}"
-vitrage_persistor_image: "{{ docker_image_url }}vitrage-persistor"
-vitrage_persistor_tag: "{{ vitrage_tag }}"
 
 ##############################
 # role: vmtp
@@ -251,15 +214,6 @@ cinder_backup_image: "{{ docker_image_url }}cinder-backup"
 cinder_backup_tag: "{{ cinder_tag }}"
 cinder_api_image: "{{ docker_image_url }}cinder-api"
 cinder_api_tag: "{{ cinder_tag }}"
-
-##############################
-# role: freezer
-
-freezer_tag: "{{ kolla_freezer_version|default(kolla_image_version) }}"
-freezer_api_image: "{{ docker_image_url }}freezer-api"
-freezer_api_tag: "{{ freezer_tag }}"
-freezer_scheduler_image: "{{ docker_image_url }}freezer-scheduler"
-freezer_scheduler_tag: "{{ freezer_tag }}"
 
 ##############################
 # role: kibana
@@ -323,15 +277,6 @@ magnum_api_image: "{{ docker_image_url }}magnum-api"
 magnum_api_tag: "{{ magnum_tag }}"
 magnum_conductor_image: "{{ docker_image_url }}magnum-conductor"
 magnum_conductor_tag: "{{ magnum_tag }}"
-
-##############################
-# role: sahara
-
-sahara_tag: "{{ kolla_sahara_version|default(kolla_image_version) }}"
-sahara_engine_image: "{{ docker_image_url }}sahara-engine"
-sahara_engine_tag: "{{ sahara_tag }}"
-sahara_api_image: "{{ docker_image_url }}sahara-api"
-sahara_api_tag: "{{ sahara_tag }}"
 
 ##############################
 # role: loadbalancer
@@ -705,15 +650,6 @@ ironic_dnsmasq_image: "{{ docker_image_url }}dnsmasq"
 ironic_dnsmasq_tag: "{{ kolla_dnsmasq_version|default(kolla_image_version) }}"
 ironic_prometheus_exporter_image: "{{ docker_image_url }}ironic-prometheus-exporter"
 ironic_prometheus_exporter_tag: "{{ kolla_ironic_prometheus_exporter_version|default(kolla_image_version) }}"
-
-##############################
-# role: skydive
-
-skydive_tag: "{{ kolla_skydive_version|default(kolla_image_version) }}"
-skydive_analyzer_image: "{{ docker_image_url }}skydive-analyzer"
-skydive_analyzer_tag: "{{ skydive_tag }}"
-skydive_agent_image: "{{ docker_image_url }}skydive-agent"
-skydive_agent_tag: "{{ skydive_tag }}"
 
 ##############################
 # role: iscsi

--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -210,19 +210,11 @@ enable_swift: "no"
 keystone_admin_port: "35357"
 keystone_admin_listen_port: "{{ keystone_admin_port }}"
 
-enable_horizon_senlin: "{{ enable_senlin | bool }}"
 enable_ironic_pxe_uefi: "no"
-enable_senlin: "no"
 
 enable_outward_rabbitmq: "no"
 outward_rabbitmq_external_fqdn: "{{ kolla_external_fqdn }}"
 outward_rabbitmq_management_port: "15674"
 outward_rabbitmq_port: "5674"
-
-senlin_internal_fqdn: "{{ kolla_internal_fqdn }}"
-senlin_external_fqdn: "{{ kolla_external_fqdn }}"
-senlin_api_port: "8778"
-senlin_api_listen_port: "{{ senlin_api_port }}"
-senlin_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else senlin_api_port }}"
 
 enable_prometheus_msteams: "no"

--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -205,25 +205,14 @@ gnocchi_statsd_enable_healthchecks: "no"
 
 # required to be backward compatible
 enable_ironic_dnsmasq: "no"
-enable_skydive: "no"
 enable_swift: "no"
 
 keystone_admin_port: "35357"
 keystone_admin_listen_port: "{{ keystone_admin_port }}"
 
-enable_freezer: "no"
-enable_horizon_freezer: "no"
-enable_horizon_murano: "no"
-enable_horizon_sahara: "no"
 enable_horizon_senlin: "{{ enable_senlin | bool }}"
-enable_horizon_solum: "no"
-enable_horizon_vitrage: "no"
 enable_ironic_pxe_uefi: "no"
-enable_murano: "no"
-enable_sahara: "no"
 enable_senlin: "no"
-enable_solum: "no"
-enable_vitrage: "no"
 
 enable_outward_rabbitmq: "no"
 outward_rabbitmq_external_fqdn: "{{ kolla_external_fqdn }}"

--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -210,9 +210,4 @@ enable_swift: "no"
 keystone_admin_port: "35357"
 keystone_admin_listen_port: "{{ keystone_admin_port }}"
 
-enable_outward_rabbitmq: "no"
-outward_rabbitmq_external_fqdn: "{{ kolla_external_fqdn }}"
-outward_rabbitmq_management_port: "15674"
-outward_rabbitmq_port: "5674"
-
 enable_prometheus_msteams: "no"

--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -210,8 +210,6 @@ enable_swift: "no"
 keystone_admin_port: "35357"
 keystone_admin_listen_port: "{{ keystone_admin_port }}"
 
-enable_ironic_pxe_uefi: "no"
-
 enable_outward_rabbitmq: "no"
 outward_rabbitmq_external_fqdn: "{{ kolla_external_fqdn }}"
 outward_rabbitmq_management_port: "15674"


### PR DESCRIPTION
## What

Remove OSISM config for OpenStack services that upstream kolla-ansible
has removed and no longer defines at any supported release
(2024.1–2025.2). The config was left behind when the services went away.

Removed across `all/099-kolla.yml` and `all/002-images-kolla.yml`:

- **Six fully-dropped services** — `freezer`, `murano`, `sahara`, `solum`,
  `vitrage`, `skydive`: their `enable_*` flags, the `enable_horizon_*`
  dashboard toggles, and their image-definition blocks.
- **senlin** — `enable_senlin` + the coupled `enable_horizon_senlin`
  (defined as `"{{ enable_senlin | bool }}"`), its endpoint companion vars
  (`senlin_internal_fqdn`, `senlin_external_fqdn`, `senlin_api_port`,
  `senlin_api_listen_port`, `senlin_api_public_port`) and its image block.
- **ironic_pxe_uefi** — only the orphaned `enable_ironic_pxe_uefi` flag;
  the PXE/UEFI capability itself still exists in the ironic role under
  different variables.
- **outward_rabbitmq** — the whole block (`enable_outward_rabbitmq` plus
  `outward_rabbitmq_external_fqdn` / `_management_port` / `_port`).

## Why

These are genuine orphans: each `enable_*` flag is absent from upstream
kolla-ansible's enable-defaults across the whole supported release range,
and the companion/image vars only existed to serve those dead services.
None are OSISM inventions, and none of the removed vars are referenced
elsewhere in the OSISM repos (verified). Surfaced by the image-drift
detector's `kolla_enablement_orphan` (enable flags) and
`kolla_orphan_config` (companion/image vars) checks. Split into one commit
per concern for review.

## Note

The 2024.1/2024.2 `kolla-rabbitmq` playbooks still reference
`outward_rabbitmq_management_port` / `_port` without a default. Default
deploys are unaffected (the enable tag is `default('false')`-guarded), but
an operator opting into outward_rabbitmq on those older releases must now
set those two ports in site config (alongside the other outward_rabbitmq
secrets they already supply). Fully retiring the feature from the 2024.x
playbooks is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)