### PR TITLE
Remove rook node label defaults

### DIFF
--- a/rook-mds/000-defaults.yml
+++ b/rook-mds/000-defaults.yml
@@ -1,3 +1,0 @@
----
-k3s_add_labels__rook_mds:
-  - node-role.osism.tech/rook-mds=true

--- a/rook-mgr/000-defaults.yml
+++ b/rook-mgr/000-defaults.yml
@@ -1,3 +1,0 @@
----
-k3s_add_labels__rook_mgr:
-  - node-role.osism.tech/rook-mgr=true

--- a/rook-mon/000-defaults.yml
+++ b/rook-mon/000-defaults.yml
@@ -1,3 +1,0 @@
----
-k3s_add_labels__rook_mon:
-  - node-role.osism.tech/rook-mon=true

--- a/rook-osd/000-defaults.yml
+++ b/rook-osd/000-defaults.yml
@@ -1,3 +1,0 @@
----
-k3s_add_labels__rook_osd:
-  - node-role.osism.tech/rook-osd=true

--- a/rook-rgw/000-defaults.yml
+++ b/rook-rgw/000-defaults.yml
@@ -1,3 +1,0 @@
----
-k3s_add_labels__rook_rgw:
-  - node-role.osism.tech/rook-rgw=true


### PR DESCRIPTION
Rook is being removed as a Ceph deployment option across OSISM. The rook-mds, rook-mgr, rook-mon, rook-osd and rook-rgw defaults only provided the k3s_add_labels__rook_* node labels for the matching rook inventory groups, which are being removed as well. Nothing else references these variables.

Part of osism/issues#1398.

Assisted-by: Claude:claude-opus-4-8