### PR TITLE
Fix 2025.2 upgrade blockers (group_vars, proxysql, horizon)

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -494,6 +494,7 @@ keystone_public_port: "{{ haproxy_single_external_frontend_public_port if haprox
 keystone_public_listen_port: "5000"
 keystone_internal_port: "5000"
 keystone_internal_listen_port: "{{ keystone_internal_port }}"
+keystone_listen_port: "{{ keystone_internal_listen_port }}"
 
 keystone_ssh_port: "8023"
 
@@ -892,6 +893,7 @@ enable_ironic_dnsmasq: "{{ enable_ironic | bool }}"
 enable_ironic_inspector: "no"
 enable_ironic_neutron_agent: "no"
 enable_ironic_prometheus_exporter: "{{ enable_ironic | bool and enable_prometheus | bool }}"
+enable_ironic_pxe_filter: "no"
 enable_iscsid: "{{ enable_cinder | bool and enable_cinder_backend_iscsi | bool }}"
 enable_kuryr: "no"
 enable_letsencrypt: "no"
@@ -1243,7 +1245,16 @@ nova_console: "novnc"
 #######################
 # Nova Database
 #######################
+nova_database_address: "{{ database_address | put_address_in_context('url') }}:{{ database_port }}"
+nova_database_name: "nova"
 nova_database_shard_id: "{{ mariadb_default_database_shard_id | int }}"
+nova_database_user: "{% if use_preconfigured_databases | bool and use_common_mariadb_user | bool %}{{ database_user }}{% else %}nova{% endif %}"
+
+nova_cell0_database_address: "{{ nova_database_address }}"
+nova_cell0_database_name: "{{ nova_database_name }}_cell0"
+nova_cell0_database_password: "{{ nova_database_password }}"
+nova_cell0_database_shard_id: "{{ nova_database_shard_id | int }}"
+nova_cell0_database_user: "{{ nova_database_user }}"
 
 #######################
 # Horizon options

--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -70,6 +70,11 @@ enable_mariabackup: "yes"
 
 # horizon
 horizon_backend_database: "yes"
+# 2025.2 switched Horizon to uWSGI (horizon_wsgi_provider defaults to uwsgi);
+# behind HAProxy the uWSGI backend must listen on the unprivileged 8080, not
+# the privileged 80. Match upstream for 2025.2+, keep the pre-uWSGI value for
+# <= 2025.1.
+horizon_listen_port: "{{ '8080' if (enable_haproxy | bool and openstack_version not in ['2024.1', '2024.2', '2025.1']) else horizon_tls_port if horizon_enable_tls_backend | bool else horizon_port }}"
 
 # ironic
 ironic_agent_files_directory: /share/ironic

--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -28,8 +28,10 @@ enable_prometheus_openstack_exporter: "no"
 # We don't usually use heat anywhere. Enable it explicitly if required.
 enable_heat: "no"
 
-# Backward compatibility for < 2025.1
-enable_proxysql: "no"
+# ProxySQL became the default MariaDB load balancer in 2025.2 (the internal
+# HAProxy MariaDB frontend was removed upstream); enable it for 2025.2+, keep
+# HAProxy for <= 2025.1.
+enable_proxysql: "{{ 'no' if openstack_version in ['2024.1', '2024.2', '2025.1'] else 'yes' }}"
 
 proxysql_version: 3
 


### PR DESCRIPTION
## Summary

Three targeted fixes to unblock OpenStack **2025.2** deploy/upgrade.
`osism/defaults` mirrors upstream kolla-ansible `group_vars/all` but is synced to
`stable/2025.1`, so it diverged from 2025.2; these are the divergences that break
a 2025.2 run. Every change is **additive or release-gated**, so older supported
releases (2024.1 / 2024.2 / 2025.1) are unaffected.

## Changes

- **Add missing 2025.2 group_vars** (`all/001-kolla-defaults.yml`), verbatim from
  upstream `stable/2025.2`:
  - `keystone_listen_port` — added in the 2025.2 uWSGI migration; when undefined
    it aborts the keystone service upgrade on every control node.
  - `enable_ironic_pxe_filter` — referenced by the ironic role (bites where
    ironic is enabled, e.g. metalbox).
  - nova cells DB globals — `nova_database_{address,name,user}` and
    `nova_cell0_database_{address,name,password,shard_id,user}`.

  Purely additive and union-safe: these variables are new in 2025.2, so they are
  inert on older releases (their roles don't reference them).

- **Gate `enable_proxysql` by release** (`all/099-kolla.yml`). 2025.2 made
  ProxySQL the default MariaDB load balancer and removed the internal HAProxy
  MariaDB frontend from the mariadb role. OSISM's unconditional
  `enable_proxysql: "no"` then leaves MariaDB with no LB frontend on 2025.2
  (`VIP:3306` refused). Now on for 2025.2+, off for ≤2025.1 — mirroring the
  existing `enable_redis`/`enable_valkey` gate. `mariadb_loadbalancer` already
  derives from `enable_proxysql`, so the LB selection follows.

- **Fix horizon uWSGI listen port** (`all/099-kolla.yml`). 2025.2 switched
  Horizon to uWSGI by default (the same migration as keystone). Behind HAProxy
  the uWSGI backend must listen on the unprivileged `8080`, not the privileged
  `80`; upstream added an `'8080' if enable_haproxy` branch that OSISM lacked.
  Release-gated so 2024.x/2025.1 (still Apache) keep the previous value exactly.

## Testing

- YAML parses; `yamllint` clean w.r.t. these changes; all transitive variable
  references resolve.
- The `keystone_listen_port` and `enable_proxysql` failures were reproduced on
  live `10.1.0 → 2025.2` upgrades. `horizon_listen_port` is confirmed at the role
  level (uWSGI is the 2025.2 default; the port split is required behind HAProxy)
  but not yet exercised end-to-end — hence **draft**, pending a `2025.2` upgrade
  CI run.

## Out of scope / follow-ups

- Broader `osism/defaults` re-sync against upstream 2025.2 — relocate
  upstream-dropped vars (venus / redis / ironic_inspector / …) into a
  `# Backward compatibility for 2025.1` section.
- `nova_cell0_database_password` resolves to the `nova_database_password`
  **secret** (`passwords.yml`), which must be present on upgrades — separate
  secrets-backfill concern.
- ansible-core 2.19 templating fixes (deferred; OSISM pins ansible-core 2.18.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
