### PR TITLE
kolla: gate prometheus image by release

### DIFF
--- a/all/002-images-kolla.yml
+++ b/all/002-images-kolla.yml
@@ -319,7 +319,7 @@ glance_tls_proxy_tag: "{{ glance_tag }}"
 # role: prometheus
 
 prometheus_tag: "{{ kolla_prometheus_version|default(kolla_image_version) }}"
-prometheus_server_image: "{{ docker_image_url }}{{ 'prometheus-server' if openstack_version in ['2025.1'] else 'prometheus-v2-server' }}"
+prometheus_server_image: "{{ docker_image_url }}{{ 'prometheus-v2-server' if openstack_version in ['2024.1', '2024.2'] else 'prometheus-server' }}"
 prometheus_server_tag: "{{ prometheus_tag }}"
 prometheus_haproxy_exporter_image: "{{ docker_image_url }}prometheus-haproxy-exporter"
 prometheus_haproxy_exporter_tag: "{{ kolla_prometheus_haproxy_exporter_version|default(prometheus_tag) }}"


### PR DESCRIPTION
## What

`prometheus_server_image` resolved to the **unbuilt** `prometheus-v2-server`
image on `openstack_version == 2025.2`, breaking the `prometheus` monitoring
stage of any 2025.2 deploy or upgrade:

```
docker.errors.APIError: 500 Server Error ... unknown:
artifact kolla/prometheus-v2-server:2025.2 not found
→ monitoring stage failed
```

`registry.osism.tech/kolla/prometheus-server:2025.2` exists;
`kolla/prometheus-v2-server:2025.2` does not.

## Root cause

Kolla renamed the image at 2025.1 (Prometheus 2.x → 3.x, `prometheus-v2-server`
→ `prometheus-server`) and only builds `prometheus-v2-server` for **2024.1 /
2024.2**. The gate encoded "2025.1 and later" as an exact **allowlist**:

```jinja
'prometheus-server' if openstack_version in ['2025.1'] else 'prometheus-v2-server'
```

so every release newer than 2025.1 not explicitly added to the list silently
fell through to the legacy `else` branch. `2025.2` did not exist when the
allowlist was introduced, so it resolved to the retired image.

## Fix

Invert the gate into a legacy **denylist** — name the two releases that actually
build `prometheus-v2-server` and default to `prometheus-server` for everything
else:

```jinja
'prometheus-v2-server' if openstack_version in ['2024.1', '2024.2'] else 'prometheus-server'
```

`2025.2`, `master`, and every future release now resolve correctly with **no
list maintenance**. This matches the forward-safe shape already used by the
`redis` / `valkey` / `proxysql` gates in `all/099-kolla.yml`.

Rejected alternatives: extending the allowlist to `['2025.1', '2025.2']` (still
an "and-later" list — rots again at 2025.3), and a raw `>=` string comparison
(mis-sorts legacy codenames, e.g. `'victoria' >= '2025.1'` is lexically true).

## Audit

This change came out of a sweep of **every** `openstack_version` list gate in
the repo. Of the six gates, this `prometheus_server_image` line was the **sole**
"and-later as an allowlist" offender. The other five are already forward-safe —
they either list old releases with the modern value in the fallback branch
(`enable_redis`, `enable_valkey`, `enable_proxysql`, `mariadb_image`) or use a
`not in` denylist (`horizon_listen_port`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
