### PR TITLE
Default cilium_bgp to false

### DIFF
--- a/all/099-k3s.yml
+++ b/all/099-k3s.yml
@@ -33,7 +33,15 @@ cilium_mode: "native"
 cilium_cli: false
 cilium_hubble: false
 cilium_hubble_ui_lb: true
-cilium_bgp: true
+# Cilium BGP is opt-in: with cilium_bgp: true the MetalLB pool is not deployed
+# at all (osism/osism-kubernetes roles/k3s_server/tasks/main.yml and
+# roles/k3s_server_post/tasks/main.yml both gate it on
+# `not cilium_bgp or cilium_iface is not defined`, and 099-interfaces.yml always
+# defines cilium_iface). Load balancer addresses are then announced over BGP to
+# cilium_bgp_peer_address, which defaults to frr_loopback_v4 | default('127.0.0.1').
+# Without an FRR peer that means every type=LoadBalancer service stays <pending>
+# forever with no error anywhere, and metal_lb_ip_range is silently inert.
+cilium_bgp: false
 
 cilium_bgp_my_asn: "64513"
 cilium_bgp_peer_asn: "{{ frr_local_as | default('64512') }}"


### PR DESCRIPTION
Change the default of `cilium_bgp` from `true` to `false` in `all/099-k3s.yml`.

### The problem

With `cilium_bgp: true` the MetalLB pool is **never deployed**. Both places that deploy it in
`osism/osism-kubernetes` gate it on the same condition:

- `roles/k3s_server/tasks/main.yml`
- `roles/k3s_server_post/tasks/main.yml`

```yaml
when: kube_vip_lb_ip_range is not defined and (not cilium_bgp or cilium_iface is not defined)
```

`all/099-interfaces.yml` always defines `cilium_iface`:

```yaml
cilium_iface: "{{ k3s_interface }}"
```

So with the shipped defaults `cilium_bgp` is true and `cilium_iface` is defined, the condition
is always false, and MetalLB is skipped. LoadBalancer addresses are instead announced over
Cilium BGP to `cilium_bgp_peer_address`, which defaults to:

```yaml
cilium_bgp_peer_address: "{{ frr_loopback_v4 | default('127.0.0.1') }}"
```

### The consequence

On any deployment without an FRR peer — which is every deployment that has not deliberately
set one up — the result is a cluster where **every `type=LoadBalancer` service sits in
`<pending>` indefinitely**, `metal_lb_ip_range` is silently ignored, and nothing is logged as
an error. The cluster otherwise looks completely healthy, which makes this expensive to
diagnose: the natural assumption is a MetalLB problem, but MetalLB was never installed.

### Evidence

Verified on a k3s 1.36.3 deployment with no BGP infrastructure. With the shipped defaults, no
MetalLB resources were created. Setting `cilium_bgp: false` produced a working MetalLB layer2
setup on the next run: the `first-pool` IPAddressPool and L2Advertisement appeared, a test
`type=LoadBalancer` service was assigned an address from the configured range, and it answered
from on-link and from another subnet.

### Why this default

BGP is an opt-in topology that requires infrastructure outside the cluster. Defaulting it off
means the shipped configuration works standalone, and turning it on becomes an explicit
choice that makes the FRR dependency visible. Nothing is lost for BGP users beyond setting
one variable.

An alternative would be to keep the default and fail fast in `k3s_server_post` when
`cilium_bgp` is true and no reachable peer is configured. That would also solve the silent
failure, and is worth considering if the current default is preferred for other reasons —
the important part is that "no working LoadBalancer" should not be a silent outcome.